### PR TITLE
Update variables.less

### DIFF
--- a/bootstrap/less/variables.less
+++ b/bootstrap/less/variables.less
@@ -76,7 +76,7 @@
 //## Specify custom location and filename of the included Glyphicons icon font. Useful for those including Bootstrap via Bower.
 
 //** Load fonts from this directory.
-@icon-font-path:          "./bootstrap/fonts/";
+@icon-font-path:          "../fonts/";
 //** File name for all font files.
 @icon-font-name:          "glyphicons-halflings-regular";
 //** Element ID within SVG icon file.


### PR DESCRIPTION
Fixed @icon-font-path value to properly load glyphicon font.

Current value seems to generate incorrect path to the fonts:

```
http://www.website.com/wp-content/themes/theme_slug/bootstrap/less/bootstrap/fonts/glyphicons-halflings-regular.woff2
http://www.website.com/wp-content/themes/theme_slug/bootstrap/less/bootstrap/fonts/glyphicons-halflings-regular.woff
http://www.website.com/wp-content/themes/theme_slug/bootstrap/less/bootstrap/fonts/glyphicons-halflings-regular.ttf
```
